### PR TITLE
Commons File Upload java.lang.NoClassDefFoundError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>mime-types</artifactId>
             <version>1.0.4</version>
         </dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.5</version>
+        </dependency>        
         <!-- Barcode -->
         <dependency>
             <groupId>io.nayuki</groupId>


### PR DESCRIPTION
Graalvm is throwing the warnings:

Warning: Could not register org.primefaces.model.file.CommonsUploadedFile: allDeclaredConstructors for reflection. Reason: java.lang.NoClassDefFoundError: org/apache/commons/fileupload/FileItem.
Warning: Could not register org.primefaces.model.file.CommonsUploadedFile: allDeclaredFields for reflection. Reason: java.lang.NoClassDefFoundError: org/apache/commons/fileupload/FileItem.

This dependency clears that warning.